### PR TITLE
Send 'X-Ajax-Browser-Auth' header on requests

### DIFF
--- a/app/scripts/services/RequestInterceptor.coffee
+++ b/app/scripts/services/RequestInterceptor.coffee
@@ -26,6 +26,7 @@ angular.module('neo4jApp.services')
     (AuthDataService) ->
       interceptor =
         request: (config) ->
+          config.headers['X-Ajax-Browser-Auth'] = true
           isLocalRequest = yes
           if /^https?:/.test config.url
             url = document.location.origin || window.location.protocol + "//" + window.location.host

--- a/test/spec/other/RequestHeaders.coffee
+++ b/test/spec/other/RequestHeaders.coffee
@@ -1,0 +1,57 @@
+###!
+Copyright (c) 2002-2015 "Neo Technology,"
+Network Engine for Objects in Lund AB [http://neotechnology.com]
+
+This file is part of Neo4j.
+
+Neo4j is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###
+
+'use strict'
+
+describe 'AJAX Header', () ->
+  [backend, node, rel] = [null, null, null]
+  Settings = {}
+
+  # load the service's module
+  beforeEach module 'neo4jApp.services'
+
+  beforeEach inject ($httpBackend) ->
+    backend = $httpBackend
+
+  afterEach ->
+    backend.verifyNoOutstandingRequest()
+
+  # instantiate service
+  Cypher = {}
+  scope = {}
+  beforeEach inject (_Cypher_, $rootScope, _Settings_) ->
+    Cypher = _Cypher_
+    scope = $rootScope.$new()
+    Settings = _Settings_
+
+  describe "headers for transactions:", ->
+    it 'should should add header when posting a transaction', ->
+      backend.expectPOST(/db\/data\/transaction\/commit/, undefined, (headers)->
+        headers['X-Ajax-Browser-Auth'] == true
+      ).respond(->
+        return [200, JSON.stringify({
+          commit: "http://localhost:9000#{Settings.endpoint.transaction}/1/commit",
+          results: []
+          errors: []
+        })]
+      )
+      Cypher.transaction().commit('RETURN 1')
+      scope.$apply()
+      backend.flush()


### PR DESCRIPTION
- To tell server that we want to be treated
  with special response headers.