### PR TITLE
Reduce number of queries to a single one for :schema

### DIFF
--- a/app/scripts/services/Bolt.coffee
+++ b/app/scripts/services/Bolt.coffee
@@ -198,15 +198,15 @@ angular.module('neo4jApp.services')
         else
           indexString = "Indexes"
           for index in indexes
-            indexString += "\n  #{index.get('description').replace('INDEX','')} #{index.get('state').toUpperCase()}"
-            if index.get("type") == "node_unique_property"
+            indexString += "\n  #{index.description.replace('INDEX','')} #{index.state.toUpperCase()}"
+            if index.type == "node_unique_property"
               indexString += " (for uniqueness constraint)"
         if (constraints.length == 0)
           constraintsString = "No constraints"
         else
           constraintsString = "Constraints"
           for constraint in constraints
-            constraintsString += "\n  #{constraint.get('description').replace('CONSTRAINT','')}"
+            constraintsString += "\n  #{constraint.description.replace('CONSTRAINT','')}"
         return "#{indexString}\n\n#{constraintsString}\n"
 
       boltResultToRESTResult = (result) ->

--- a/app/scripts/services/UtilityBolt.coffee
+++ b/app/scripts/services/UtilityBolt.coffee
@@ -30,12 +30,18 @@ angular.module('neo4jApp.services')
         clearConnection: -> Bolt.clearConnection()
         getSchema: ->
           q = $q.defer()
-          $q.all([
-            Bolt.callProcedure("db.indexes"),
-            Bolt.callProcedure("db.constraints"),
-          ]).then((data) ->
-            q.resolve(Bolt.constructSchemaResult data[0], data[1])
-          )
+          Bolt.boltTransaction(
+            "CALL db.indexes() YIELD description, state, type " +
+            "WITH COLLECT({description: description, state: state, type: type}) AS indexes " +
+            "RETURN 'indexes' AS name, indexes AS items " +
+            "UNION " +
+            "CALL db.constraints() YIELD description " +
+            "WITH COLLECT({description: description}) AS constraints " + 
+            "RETURN 'constraints' AS name, constraints AS items"
+          ).promise.then((result) ->
+            return q.resolve(Bolt.constructSchemaResult([], [])) unless result.records.length
+            q.resolve(Bolt.constructSchemaResult result.records[0].get('items'), result.records[1].get('items'))
+          ).catch( (e) -> q.reject Bolt.constructResult e)
           q.promise
 
         getMeta: ->


### PR DESCRIPTION
This would be the ideal query:

```
CALL db.indexes() YIELD description, state, type
WITH COLLECT({description: description, state: state, type: type}) AS indexes
CALL db.constraints() YIELD description
WITH indexes, COLLECT({description: description}) AS constraints
RETURN indexes, constraints
```
but in the case of 0 constraints the indexes aren't returned either.  

So we had to do it with a `UNION` and have two rows returned instead.